### PR TITLE
Added new SUCCESS_CODES configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV HC_LOG=
 ENV TZ=
 ENV UID=
 ENV GID=
+ENV SUCCESS_CODES="0"
 
 RUN apk --no-cache add ca-certificates fuse wget dcron tzdata
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A few environment variables allow you to customize the behavior of rclone:
 * `TZ` set the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to use for the cron and log `America/Chicago`
 * `UID` set variable to specify user to run rclone as. Must also use GID.
 * `GID` set variable to specify group to run rclone as. Must also use UID.
+* `SUCCESS_CODES`: set variable to a space-separated list of return codes that are considered successful. If the return code matches any of these codes, the response will be marked as a success. Example: `SUCCESS_CODES="0 8 10"`. Default value is `0`
 
 **When using UID/GID the config and/or logs directory must be writeable by this UID**
 

--- a/sync.sh
+++ b/sync.sh
@@ -100,7 +100,6 @@ else
     echo "INFO: Define CHECK_URL with https://healthchecks.io to monitor $RCLONE_CMD job"
   else
     if is_success_code "$RETURN_CODE"; then
-    then
       if [ ! -z "$OUTPUT_LOG" ] && [ ! -z "$HC_LOG" ] && [ -f "$LOG_FILE" ]
       then
         echo "INFO: Sending complete signal with logs to healthchecks.io"

--- a/sync.sh
+++ b/sync.sh
@@ -88,7 +88,7 @@ else
   then
     echo "INFO: Define CHECK_URL with https://healthchecks.io to monitor $RCLONE_CMD job"
   else
-    if [ "$RETURN_CODE" == 0 ]
+    if [[ "$SUCCESS_CODES" =~ "$RETURN_CODE" ]]; then
     then
       if [ ! -z "$OUTPUT_LOG" ] && [ ! -z "$HC_LOG" ] && [ -f "$LOG_FILE" ]
       then

--- a/sync.sh
+++ b/sync.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+# Function to check if return code is in the success codes list
+is_success_code() {
+  local code=$1
+  for success_code in $SUCCESS_CODES; do
+    if [ "$success_code" = "$code" ]; then
+      return 0  # Match found, return success
+    fi
+  done
+  return 1  # No match found, return failure
+}
+
 echo "INFO: Starting sync.sh pid $$ $(date)"
 
 if [ `lsof | grep $0 | wc -l | tr -d ' '` -gt 1 ]
@@ -88,7 +99,7 @@ else
   then
     echo "INFO: Define CHECK_URL with https://healthchecks.io to monitor $RCLONE_CMD job"
   else
-    if [[ "$SUCCESS_CODES" =~ "$RETURN_CODE" ]]; then
+    if is_success_code "$RETURN_CODE"; then
     then
       if [ ! -z "$OUTPUT_LOG" ] && [ ! -z "$HC_LOG" ] && [ -f "$LOG_FILE" ]
       then


### PR DESCRIPTION
+ Success codes are configured by the "SUCCESS_CODES" env var
+ By default the value is "0"
+ Other codes can be specified List of exit codes
0 - success
1 - Syntax or usage error
2 - Error not otherwise categorised
3 - Directory not found
4 - File not found
5 - Temporary error (one that more retries might fix) (Retry errors)
6 - Less serious errors (like 461 errors from dropbox) (NoRetry errors) 
7 - Fatal error (one that more retries won't fix, like account suspended) (Fatal errors) 
8 - Transfer exceeded - limit set by --max-transfer reached
9 - Operation successful, but no files transferred